### PR TITLE
[DO NOT MERGE]fixed all instances i could find of ROBOT_DATA being misused

### DIFF
--- a/src/team7786/main2021/FTCBot.java
+++ b/src/team7786/main2021/FTCBot.java
@@ -11,6 +11,7 @@ import java.lang.Math.*;
 
 public class FTCBot extends MecanumRobot
 {
+  private ROBOT_DATA data = new ROBOT_DATA;
   public FTCBot(HardwareMap hwMap) {
     super(hwMap);
   }
@@ -22,10 +23,10 @@ public class FTCBot extends MecanumRobot
     bool complete = false;
     int currentState = 0;
     while (!complete) {
-      PathState state = traj.getRobotTarget(new Point(m_X, m_Y), currentState);
+      PathState state = traj.getRobotTarget(new Point(data.m_X, data.m_Y), currentState);
       currentState = state.stage;
       complete = state.complete;
-      driveTowardsPoint(state.point.x, state.point.y, m_THETA, 1d);
+      driveTowardsPoint(state.point.x, state.point.y, data.m_THETA, 1d);
       updateOdometry();
     }
     stop();
@@ -36,7 +37,7 @@ public class FTCBot extends MecanumRobot
    * @return   a double list with {x, y, rotation}
    */
   public double[] getImperialPosition() {
-    return new double[]{m_X / COUNTS_PER_INCH, m_Y / COUNTS_PER_INCH, Math.toDegrees(m_THETA)};
+    return new double[]{data.m_X / data.COUNTS_PER_INCH, data.m_Y / data.COUNTS_PER_INCH, Math.toDegrees(data.m_THETA)};
   }
 
 }

--- a/src/team7786/main2021/MecanumRobot.java
+++ b/src/team7786/main2021/MecanumRobot.java
@@ -8,7 +8,7 @@ import java.lang.Math.*;
 
 public class MecanumRobot extends Robot
 {
-
+  private ROBOT_DATA data = new ROBOT_DATA;
   // Stores the robot pose found in the last update.
   private double[] lastPose;
 
@@ -16,6 +16,7 @@ public class MecanumRobot extends Robot
   public MecanumRobot(HardwareMap hwMap) {
     super(hwMap);
     lastPose = {0d, 0d, 0d};
+
   }
 
   /** Read the current encoder values and update the last values.
@@ -49,9 +50,9 @@ public class MecanumRobot extends Robot
     double dM = (dR+dL) / 2;
     double dTheta = (dR-dL) / TRACK_WIDTH;
 
-    m_X = m_X + ((dM / dTheta) * Math.sin(dTheta) / Math.cos(dTheta)) * Math.cos(m_THETA + dTheta/2) + dB * Math.cos(m_Theta - Math.PI/2 + dTheta/2);
-    m_Y = m_Y + ((dM / dTheta) * Math.sin(dTheta) / Math.cos(dTheta)) * Math.sin(m_THETA + dTheta/2) + dB * Math.sin(m_Theta - Math.PI/2 + dTheta/2);
-    m_THETA = m_THETA + dTheta;
+    m_X = m_X + ((dM / dTheta) * Math.sin(dTheta) / Math.cos(dTheta)) * Math.cos(data.m_THETA + dTheta/2) + dB * Math.cos(data.m_Theta - Math.PI/2 + dTheta/2);
+    m_Y = m_Y + ((dM / dTheta) * Math.sin(dTheta) / Math.cos(dTheta)) * Math.sin(data.m_THETA + dTheta/2) + dB * Math.sin(data.m_Theta - Math.PI/2 + dTheta/2);
+    data.m_THETA = data.m_THETA + dTheta;
 
     reduceRotation();
   }
@@ -143,9 +144,9 @@ public class MecanumRobot extends Robot
 	}
 
   public void resetEncoders(double nL, double nR, double nB) {
-		m_LEFT_ENCODER_OFFSET = m_LEFT_ENCODER_OFFSET - getLEncoder() + nL;
-		m_RIGHT_ENCODER_OFFSET = m_RIGHT_ENCODER_OFFSET - getREncoder() + nR;
-		m_BACK_ENCODER_OFFSET = m_BACK_ENCODER_OFFSET - getBEncoder() + nB;
+		data.m_LEFT_ENCODER_OFFSET = data.m_LEFT_ENCODER_OFFSET - getLEncoder() + nL;
+		data.m_RIGHT_ENCODER_OFFSET = data.m_RIGHT_ENCODER_OFFSET - getREncoder() + nR;
+		data.m_BACK_ENCODER_OFFSET = data.m_BACK_ENCODER_OFFSET - getBEncoder() + nB;
 		resetLastEncoders(nL, nR, nB);
 
 	}

--- a/src/team7786/main2021/ROBOT_DATA.java
+++ b/src/team7786/main2021/ROBOT_DATA.java
@@ -6,28 +6,28 @@ public static class ROBOT_DATA
 
   /****************************** CONSTANTS ******************************/
   // Hardware map names
-  static const String LEFT_FRONT_NAME = "leftFrontDrive";
-  static const String = "rightFrontDrive";
-  static const String LEFT_REAR_NAME = "leftRearDrive";
-  static const String RIGHT_REAR_NAME = "rightRearDrive";
+  static final String LEFT_FRONT_NAME = "leftFrontDrive";
+  static final String RIGHT_FRONT_NAME= "rightFrontDrive";
+  static final String LEFT_REAR_NAME = "leftRearDrive";
+  static final String RIGHT_REAR_NAME = "rightRearDrive";
 
   // Drivetrain inversions
-  static const bool[] MOTOR_INVERTED = {false, true, false, true};
+  static final bool[] MOTOR_INVERTED = {false, true, false, true};
 
   // Encoder positioning and info
-  static const double COUNTS_PER_ROTATIONS = 2048d;
-  static const double DEAD_WHEEL_CIRCUMFRENCE_INCHES = 2.5d;
-  static const double TRACK_WIDTH_INCHES = 10d;                                                    // Distance between the 2 vertical encoders
-  static const double COUNTS_PER_INCH = COUNTS_PER_ROTATIONS * DEAD_WHEEL_CIRCUMFRENCE_INCHES      // DO NOT EDIT
-  static const double TRACK_WIDTH = COUNTS_PER_INCH * TRACK_WIDTH_INCHES;                          // DO NOT EDIT
+  static final double COUNTS_PER_ROTATIONS = 2048d;
+  static final double DEAD_WHEEL_CIRCUMFRENCE_INCHES = 2.5d;
+  static final double TRACK_WIDTH_INCHES = 10d;                                                    // Distance between the 2 vertical encoders
+  static final double COUNTS_PER_INCH = COUNTS_PER_ROTATIONS * DEAD_WHEEL_CIRCUMFRENCE_INCHES;     // DO NOT EDIT
+  static final double TRACK_WIDTH = COUNTS_PER_INCH * TRACK_WIDTH_INCHES;                          // DO NOT EDIT
 
 
   // Drive to point ad trajectory tuning values
-  static const double DRIVE_TO_POINT_TURN_TUNE = 1d;
-  static const double DEFAULT_LINE_FOLLOW_RANGE_INCHES = 5d;
-  static const double ABSOLUTE_TRAJECTORY_REACH_RANGE_INCHES = 0.5d;
-  static const double DEFAULT_LINE_FOLLOW_RANGE = DEFAULT_LINE_FOLLOW_RANGE_INCHES * COUNTS_PER_INCH;               // DO NOT EDIT
-  static const double ABSOLUTE_TRAJECTORY_REACH_RANGE = ABSOLUTE_TRAJECTORY_REACH_RANGE_INCHES * COUNTS_PER_INCH;   // DO NOT EDIT
+  static final double DRIVE_TO_POINT_TURN_TUNE = 1d;
+  static final double DEFAULT_LINE_FOLLOW_RANGE_INCHES = 5d;
+  static final double ABSOLUTE_TRAJECTORY_REACH_RANGE_INCHES = 0.5d;
+  static final double DEFAULT_LINE_FOLLOW_RANGE = DEFAULT_LINE_FOLLOW_RANGE_INCHES * COUNTS_PER_INCH;               // DO NOT EDIT
+  static final double ABSOLUTE_TRAJECTORY_REACH_RANGE = ABSOLUTE_TRAJECTORY_REACH_RANGE_INCHES * COUNTS_PER_INCH;   // DO NOT EDIT
 
 
 

--- a/src/team7786/main2021/Robot.java
+++ b/src/team7786/main2021/Robot.java
@@ -7,21 +7,21 @@ import team7786.main2021.ROBOT_DATA.*;
 // This code serves as a base class for a 4 motor drivetrain
 public class Robot
 {
-
+	private ROBOT_DATA data = new ROBOT_DATA;
   // Declare Drive Motors and Array
 	private DcMotor leftFrontDrive, rightRearDrive, rightFrontDrive, leftRearDrive;
 	private DcMotor[] drivers;
-	private boolean[] MOTOR_INVERTED = new boolean[4];
+
 
   /** Constructor for base class robot
    * @param hwMap     the hardware map
    */
   public Robot(HardwareMap hwMap) {
     // Initialize the motor hardware variables
-		leftFrontDrive = hwMap.get(DcMotor.class, LEFT_FRONT_NAME);
-		leftRearDrive = hwMap.get(DcMotor.class, RIGHT_FRONT_NAME);
-		rightFrontDrive = hwMap.get(DcMotor.class, LEFT_REAR_NAME);
-		rightRearDrive = hwMap.get(DcMotor.class, RIGHT_REAR_NAME);
+		leftFrontDrive = hwMap.get(DcMotor.class, data.LEFT_FRONT_NAME);
+		leftRearDrive = hwMap.get(DcMotor.class, data.RIGHT_FRONT_NAME);
+		rightFrontDrive = hwMap.get(DcMotor.class, data.LEFT_REAR_NAME);
+		rightRearDrive = hwMap.get(DcMotor.class, data.RIGHT_REAR_NAME);
 
 		// Initialize the motor array
 
@@ -30,7 +30,7 @@ public class Robot
 
     // set motor orientations (positive power should move wheel clockwise)
 		for (i = 0; i < 4; i++) {
-			if (MOTOR_INVERTED[i] == true) {
+			if (data.MOTOR_INVERTED[i] == true) {
 				drivers[i].setDirection(DcMotor.Direction.REVERSE);
 			}
 		}
@@ -76,8 +76,8 @@ public class Robot
 	}
 
 	public double reduceRotation() {
-		while (m_THETA >= Math.PI * 2 || m_THETA < 0) {
-			m_THETA = m_THETA - Math.PI * (m_THETA > 0 ? -2 : 2);
+		while (data.m_THETA >= Math.PI * 2 || m_THETA < 0) {
+			data.m_THETA = data.m_THETA - Math.PI * (m_THETA > 0 ? -2 : 2);
 		}
 	}
 

--- a/src/team7786/main2021/path/Trajectory.java
+++ b/src/team7786/main2021/path/Trajectory.java
@@ -5,7 +5,7 @@ import team7786.main2021.path.PathLine;
 import team7786.main2021.path.PathState;
 import team7786.main2021.geometry.Point;
 import team7786.main2021.geometry.Graph.*;
-import team7786.main2021.ROBOT_DATA*;
+import team7786.main2021.ROBOT_DATA.*;
 
 public class Trajectory
 {

--- a/src/team7786/main2021/path/Waypoint.java
+++ b/src/team7786/main2021/path/Waypoint.java
@@ -5,8 +5,9 @@ import team7786.main2021.ROBOT_DATA;
 
 public class Waypoint
 {
+  private ROBOT_DATA data = new ROBOT_DATA;
   public Point point;
-  public bool absolute;
+  public boolean absolute;
   public double range;
 
 
@@ -16,9 +17,9 @@ public class Waypoint
    * Will allow the robot to interpolate and form a spline to maximize smoothness
    */
   public Waypoint(double x, double y) {
-    point = new Point(x * COUNTS_PER_INCH, y * COUNTS_PER_INCH);
+    point = new Point(x * data.COUNTS_PER_INCH, y * data.COUNTS_PER_INCH);
     absolute = false;
-    range = DEFAULT_LINE_FOLLOW_RANGE;
+    range = data.DEFAULT_LINE_FOLLOW_RANGE;
   }
 
 
@@ -28,9 +29,9 @@ public class Waypoint
    * @param abs  Setting this to false will force the robot to follow this line exactly
    */
   public Waypoint(double x, double y, bool _abs) {
-    point = new Point(x * COUNTS_PER_INCH, y * COUNTS_PER_INCH);
+    point = new Point(x * data.COUNTS_PER_INCH, y * data.COUNTS_PER_INCH);
     absolute = _abs;
-    range = DEFAULT_LINE_FOLLOW_RANGE;
+    range = data.DEFAULT_LINE_FOLLOW_RANGE;
   }
 
 
@@ -41,7 +42,7 @@ public class Waypoint
    * @param accuracy    How closely the robot should follow the line (higher values mean more smoothing)
    */
   public Waypoint(double x, double y, bool _abs, double accuracy) {
-    point = new Point(x * COUNTS_PER_INCH, y * COUNTS_PER_INCH);
+    point = new Point(x * data.COUNTS_PER_INCH, y * data.COUNTS_PER_INCH);
     absolute = _abs;
     range = accuracy;
   }


### PR DESCRIPTION
\>\>\> classes are objects <<<
you cannot just call parameters of a class that has not been instantiated as an object yet, it must be instantiated to have its parameters called
ROBOT_DATA is one such object, the way that I fixed this was to create a separate, dereferenced instance of ROBOT_DATA in each class that used the data
**IF THIS APPROACH DOES NOT WORK IN PRACTICE DO NOT MERGE**
I do not know if this problem persists across the implementation of multiple classes but this is the only one in which I observed it if any of this is wrong tell me but I don't think it is
-janek